### PR TITLE
macOS related fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,8 +205,7 @@
 <br>
 <h3>Скачать для Apple Macintosh</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.dmg ">Doom2D Forever, OSX 11.0+, dmg (RUS/ENG)</a></h5></li>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_macos.intel64.zip ">Doom2D Forever, OSX 11.0+, zip (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.dmg ">Doom2D Forever, macOS 11.0+ (RUS/ENG)</a></h5></li>
 </ul>
 
 <br>


### PR DESCRIPTION
Don't give links to ZIP bundles, as they are not the preferred app distribution method. Also, don't needlessly mention that this is a `dmg`, as it is assumed by default.