### PR TITLE
Linux related fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,8 +212,8 @@
 <br>
 <h3>Скачать для Linux</h3>
 <ul>
-<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux X86, tarball (RUS/ENG)</a></h5></li>
-<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux x86_64, tarball (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux i686, tarball (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux amd64, tarball (RUS/ENG)</a></h5></li>
 <!--<p>Игра требует следующие пакеты: libgme opus opusfile libvorbis mpg123 openal enet libmodplug sdl2 xmp. Названия могут разниться между дистрибутивами.</p>-->
 <li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, Arch/Manjaro Linux, AUR-пакет (RUS/ENG)</a></h5></li>
 <p>Обсуждение <a href="/forum/viewtopic.php?f=11&t=2919">на форуме</a></p>

--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
 <li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux i686, tarball (RUS/ENG)</a></h5></li>
 <li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux amd64, tarball (RUS/ENG)</a></h5></li>
 <!--<p>Игра требует следующие пакеты: libgme opus opusfile libvorbis mpg123 openal enet libmodplug sdl2 xmp. Названия могут разниться между дистрибутивами.</p>-->
-<li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, Arch/Manjaro Linux, AUR-пакет (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, AUR-пакет</a></h5></li>
 <p>Обсуждение <a href="/forum/viewtopic.php?f=11&t=2919">на форуме</a></p>
 </ul>
 


### PR DESCRIPTION
Use more commonly used names for architectures in Linux, and remove mentions of Arch Linux for AUR package, as it is assumed by default