### PR TITLE
Windows related fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
             
 			<h3>Скачать для Windows</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG, x86)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG)</a></h5></li>
 <!-- <li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_win64.x86-64.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG, x64)</a></h5></li> -->
 <p>Актуальная версия, 2025</p>
 <br/>


### PR DESCRIPTION
Don't mention architecture for the Windows build.

This may scare some users who would think that x86 is unsupported on their 64-bit computers, and isn't really useful because there is no link for x86_64 build yet.