### PR TITLE
Remove visual clutter

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,8 +210,8 @@
 <br>
 <h3>Скачать для Linux</h3>
 <ul>
-<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux X86, tarball (RUS/ENG)</a></h5></li>
-<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux x86_64, tarball (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux i686, tarball (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux amd64, tarball (RUS/ENG)</a></h5></li>
 <!--<p>Игра требует следующие пакеты: libgme opus opusfile libvorbis mpg123 openal enet libmodplug sdl2 xmp. Названия могут разниться между дистрибутивами.</p>-->
 <li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, Arch/Manjaro Linux, AUR-пакет (RUS/ENG)</a></h5></li>
 <p>Обсуждение <a href="/forum/viewtopic.php?f=11&t=2919">на форуме</a></p>

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
             
 			<h3>Скачать для Windows</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG, x86)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG)</a></h5></li>
 <!-- <li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_win64.x86-64.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG, x64)</a></h5></li> -->
 <p>Актуальная версия, 2025</p>
 <br/>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
 <li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux i686, tarball (RUS/ENG)</a></h5></li>
 <li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux amd64, tarball (RUS/ENG)</a></h5></li>
 <!--<p>Игра требует следующие пакеты: libgme opus opusfile libvorbis mpg123 openal enet libmodplug sdl2 xmp. Названия могут разниться между дистрибутивами.</p>-->
-<li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, Arch/Manjaro Linux, AUR-пакет (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, AUR-пакет</a></h5></li>
 <p>Обсуждение <a href="/forum/viewtopic.php?f=11&t=2919">на форуме</a></p>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -205,8 +205,7 @@
 <br>
 <h3>Скачать для Apple Macintosh</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.dmg ">Doom2D Forever, OSX 11.0+, dmg (RUS/ENG)</a></h5></li>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_macos.intel64.zip ">Doom2D Forever, OSX 11.0+, zip (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.dmg ">Doom2D Forever, macOS 11.0+ (RUS/ENG)</a></h5></li>
 </ul>
 
 <br>

--- a/index.html
+++ b/index.html
@@ -198,8 +198,7 @@
 <br>
 <h3>Скачать для Android</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.apk">Doom2D Forever, Android (RUS/ENG)</a></h5></li>
-
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.apk">Doom2D Forever, Android 4.0.1+ (RUS/ENG)</a></h5></li>
 </ul>
 
 <br>

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
             
 			<h3>Скачать для Windows</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Windows XP/7/10/11 (RUS/ENG)</a></h5></li>
 <!-- <li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_win64.x86-64.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG, x64)</a></h5></li> -->
 <p>Актуальная версия, 2025</p>
 <br/>
@@ -198,22 +198,22 @@
 <br>
 <h3>Скачать для Android</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.apk">Doom2D Forever, Android 4.0.1+ (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.apk">Android 4.0.1+ (RUS/ENG)</a></h5></li>
 </ul>
 
 <br>
 <h3>Скачать для Apple Macintosh</h3>
 <ul>
-<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.dmg ">Doom2D Forever, macOS 11.0+ (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/Doom2D-Forever.dmg ">macOS 11.0+ (RUS/ENG)</a></h5></li>
 </ul>
 
 <br>
 <h3>Скачать для Linux</h3>
 <ul>
-<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">Doom2D Forever, Linux i686, tarball (RUS/ENG)</a></h5></li>
-<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">Doom2D Forever, Linux amd64, tarball (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-i386.tar.gz">i686, tarball (RUS/ENG)</a></h5></li>
+<li><h5><a href="https://deadsoftware.ru/files/terminalhash/d2df-linux-amd64.tar.gz">amd64, tarball (RUS/ENG)</a></h5></li>
 <!--<p>Игра требует следующие пакеты: libgme opus opusfile libvorbis mpg123 openal enet libmodplug sdl2 xmp. Названия могут разниться между дистрибутивами.</p>-->
-<li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">Doom2D Forever, AUR-пакет</a></h5></li>
+<li><h5><a href="https://aur.archlinux.org/packages/doom2df-bin/">AUR-пакет</a></h5></li>
 <p>Обсуждение <a href="/forum/viewtopic.php?f=11&t=2919">на форуме</a></p>
 </ul>
 

--- a/index.html
+++ b/index.html
@@ -188,11 +188,6 @@
 <ul>
 <li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_windows.x86.zip">Windows XP/7/10/11 (RUS/ENG)</a></h5></li>
 <!-- <li><h5><a href="https://github.com/Doom2D/flake.nix/releases/latest/download/doom2df_win64.x86-64.zip">Doom2D Forever, Windows XP/7/10/11 (RUS/ENG, x64)</a></h5></li> -->
-<p>Актуальная версия, 2025</p>
-<br/>
-<li><h5><a href="/files/df/DFv0666.php">Doom2D Forever v0.666, Windows 9x (RUS/ENG, x86)</a></h5>
-	<p>Устаревшая версия с поддержкой Win9x, 2014. Не вполне совместима с актуальной</p>
-	</li>
 </ul>
 
 <br>


### PR DESCRIPTION
Remove "Doom2D-Forever" duplicated in each link. Remove old v0.666 version.